### PR TITLE
add Image Labels buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -39,6 +39,11 @@ api = "0.5"
     optional = true
     version = "3.1.1"
 
+  [[order.group]]
+    id = "paketo-buildpacks/image-labels"
+    optional = true
+    version = "3.1.2"
+
 [[order]]
 
   [[order.group]]
@@ -67,6 +72,11 @@ api = "0.5"
     optional = true
     version = "3.1.1"
 
+  [[order.group]]
+    id = "paketo-buildpacks/image-labels"
+    optional = true
+    version = "3.1.2"
+
 [[order]]
 
   [[order.group]]
@@ -91,6 +101,11 @@ api = "0.5"
     optional = true
     version = "3.1.1"
 
+  [[order.group]]
+    id = "paketo-buildpacks/image-labels"
+    optional = true
+    version = "3.1.2"
+
 [[order]]
 
   [[order.group]]
@@ -110,3 +125,8 @@ api = "0.5"
     id = "paketo-buildpacks/environment-variables"
     optional = true
     version = "3.1.1"
+
+  [[order.group]]
+    id = "paketo-buildpacks/image-labels"
+    optional = true
+    version = "3.1.2"

--- a/integration/conda_test.go
+++ b/integration/conda_test.go
@@ -62,6 +62,7 @@ func testConda(t *testing.T, context spec.G, it spec.S) {
 				WithPullPolicy("never").
 				WithEnv(map[string]string{
 					"BPE_SOME_VARIABLE": "some-value",
+					"BP_IMAGE_LABELS":   "some-label=some-value",
 				}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String())
@@ -90,9 +91,11 @@ func testConda(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Python Start Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
 
 			Expect(image.Buildpacks[4].Key).To(Equal("paketo-buildpacks/environment-variables"))
 			Expect(image.Buildpacks[4].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+			Expect(image.Labels["some-label"]).To(Equal("some-value"))
 		})
 	})
 }

--- a/integration/pip_test.go
+++ b/integration/pip_test.go
@@ -62,6 +62,7 @@ func testPip(t *testing.T, context spec.G, it spec.S) {
 				WithPullPolicy("never").
 				WithEnv(map[string]string{
 					"BPE_SOME_VARIABLE": "some-value",
+					"BP_IMAGE_LABELS":   "some-label=some-value",
 				}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String())
@@ -91,9 +92,11 @@ func testPip(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Python Start Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
 
 			Expect(image.Buildpacks[5].Key).To(Equal("paketo-buildpacks/environment-variables"))
 			Expect(image.Buildpacks[5].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+			Expect(image.Labels["some-label"]).To(Equal("some-value"))
 		})
 	})
 }

--- a/integration/pipenv_test.go
+++ b/integration/pipenv_test.go
@@ -62,6 +62,7 @@ func testPipenv(t *testing.T, context spec.G, it spec.S) {
 				WithPullPolicy("never").
 				WithEnv(map[string]string{
 					"BPE_SOME_VARIABLE": "some-value",
+					"BP_IMAGE_LABELS":   "some-label=some-value",
 				}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String())
@@ -92,9 +93,11 @@ func testPipenv(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Python Start Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
 
 			Expect(image.Buildpacks[6].Key).To(Equal("paketo-buildpacks/environment-variables"))
 			Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+			Expect(image.Labels["some-label"]).To(Equal("some-value"))
 		})
 	})
 }

--- a/package.toml
+++ b/package.toml
@@ -31,3 +31,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/environment-variables:3.1.1"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/image-labels:3.1.2"


### PR DESCRIPTION
This addition adds the Image Labels buildpack to the order groupings, which will resolve #187. Integration tests are also added to ensure they work in each order group.